### PR TITLE
Make clock ratio configurable.

### DIFF
--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -98,6 +98,7 @@ CPS2VM::CPS2VM()
 	m_OnCrtModeChangeConnection = m_ee->m_os->OnCrtModeChange.Connect(std::bind(&CPS2VM::OnCrtModeChange, this));
 
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREF_PS2_LIMIT_FRAMERATE, true);
+	CAppConfig::GetInstance().RegisterPreferenceInteger(PREF_PS2_CLOCK_RATIO, 100);
 	ReloadFrameRateLimit();
 
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREF_AUDIO_SPUBLOCKCOUNT, 100);
@@ -174,7 +175,9 @@ void CPS2VM::ReloadFrameRateLimit()
 	bool limitFrameRate = CAppConfig::GetInstance().GetPreferenceBoolean(PREF_PS2_LIMIT_FRAMERATE);
 	m_frameLimiter.SetFrameRate(limitFrameRate ? frameRate : 0);
 
-	uint32 frameTicks = PS2::EE_CLOCK_FREQ / frameRate;
+	uint32 clockRatio = CAppConfig::GetInstance().GetPreferenceInteger(PREF_PS2_CLOCK_RATIO);
+	uint32 frameTicks = (PS2::EE_CLOCK_FREQ / frameRate);
+	frameTicks = (frameTicks * clockRatio) / 100;
 	m_onScreenTicksTotal = frameTicks * 9 / 10;
 	m_vblankTicksTotal = frameTicks / 10;
 }

--- a/Source/PS2VM_Preferences.h
+++ b/Source/PS2VM_Preferences.h
@@ -9,6 +9,7 @@
 #define PREF_PS2_HDD_DIRECTORY ("ps2.hdd.directory")
 
 #define PREF_PS2_LIMIT_FRAMERATE ("ps2.limitframerate")
+#define PREF_PS2_CLOCK_RATIO ("ps2.clockratio")
 
 #define PREF_AUDIO_SPUBLOCKCOUNT ("audio.spublockcount")
 

--- a/Source/ui_qt/Qt_ui/settingsdialog.ui
+++ b/Source/ui_qt/Qt_ui/settingsdialog.ui
@@ -189,6 +189,42 @@
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Clock Ratio:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="comboBox_clock_ratio">
+         <item>
+          <property name="text">
+           <string>100%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>75%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>50%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>25%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>10%</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
         <widget class="QCheckBox" name="checkBox_limitFrameRate">
          <property name="text">
           <string>Cap Frame Rate to Video Refresh Rate</string>

--- a/Source/ui_qt/settingsdialog.cpp
+++ b/Source/ui_qt/settingsdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_settingsdialog.h"
 #include "PS2VM_Preferences.h"
 #include "PreferenceDefs.h"
+#include "string_format.h"
 #include "../gs/GSH_OpenGL/GSH_OpenGL.h"
 #include <cassert>
 #include <cmath>
@@ -81,6 +82,17 @@ void SettingsDialog::LoadPreferences()
 	ui->comboBox_system_language->setCurrentIndex(CAppConfig::GetInstance().GetPreferenceInteger(PREF_SYSTEM_LANGUAGE));
 	ui->checkBox_limitFrameRate->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_PS2_LIMIT_FRAMERATE));
 
+	{
+		std::string clockRatioString = string_format("%d%%", CAppConfig::GetInstance().GetPreferenceInteger(PREF_PS2_CLOCK_RATIO));
+		int index = ui->comboBox_clock_ratio->findText(clockRatioString.c_str());
+		//If ratio not found, just use the first entry
+		if(index == -1)
+		{
+			index = 0;
+		}
+		ui->comboBox_clock_ratio->setCurrentIndex(index);
+	}
+
 	int factor = CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR);
 	int factor_index = std::log2(factor);
 	ui->comboBox_res_multiplyer->setCurrentIndex(factor_index);
@@ -98,6 +110,14 @@ void SettingsDialog::LoadPreferences()
 void SettingsDialog::on_comboBox_system_language_currentIndexChanged(int index)
 {
 	CAppConfig::GetInstance().SetPreferenceInteger(PREF_SYSTEM_LANGUAGE, index);
+}
+
+void SettingsDialog::on_comboBox_clock_ratio_currentIndexChanged(int index)
+{
+	auto itemText = ui->comboBox_clock_ratio->itemText(index);
+	int ratio = 100;
+	sscanf(itemText.toStdString().c_str(), "%d%%", &ratio);
+	CAppConfig::GetInstance().SetPreferenceInteger(PREF_PS2_CLOCK_RATIO, ratio);
 }
 
 void SettingsDialog::on_checkBox_limitFrameRate_clicked(bool checked)

--- a/Source/ui_qt/settingsdialog.h
+++ b/Source/ui_qt/settingsdialog.h
@@ -34,6 +34,7 @@ private slots:
 
 	//General Page
 	void on_comboBox_system_language_currentIndexChanged(int index);
+	void on_comboBox_clock_ratio_currentIndexChanged(int index);
 	void on_checkBox_limitFrameRate_clicked(bool checked);
 
 	//Video Page


### PR DESCRIPTION
Can be used to test effects of underclocking in real time.